### PR TITLE
Next version

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -2,6 +2,7 @@
   "types": [
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Improvements"},
+    {"type": "enhance", "section": "Improvements"},
     {"type": "debt", "section": "Debts"},
     {"type": "risk", "section": "Risks and compliance"},
     {"type": "chore", "hidden": true},

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 name: iati-workbench
 title: IATI Workbench
-version: 1.4.0-aida
-prerelease:
+version: next
+prerelease: true
 nav:
 - modules/ROOT/nav.adoc
 - modules/spreadsheets2iati/nav.adoc

--- a/docs/modules/ROOT/pages/ant-results.adoc
+++ b/docs/modules/ROOT/pages/ant-results.adoc
@@ -10,10 +10,10 @@ To capture the Ant process log as XML data, call Ant with additional parameters:
 When running within the container:
 
   $ ant -logger org.apache.tools.ant.XmlLogger -logfile /workspace/output/ant-log.xml <target>
-  
+
 When using the container image with the calling script:
 
-  $ iati-workbench -xml <target>
+  $ aida-s2i -xml <target>
 
 The Ant logfile will be stored in the workspace's `output` directory.
 
@@ -25,8 +25,8 @@ Within the container:
   $ ant ant-log-json
 
 Or via the calling script:
-  
-  $ iati-workbench ant-log-json
+
+  $ aida-s2i ant-log-json
 
 The JSON data will look like this:
 
@@ -61,7 +61,7 @@ The JSON data will look like this:
         }
       ]
     },
-    
+
     {"...etcetera..."}
   ]
 }

--- a/docs/modules/ROOT/pages/workspace.adoc
+++ b/docs/modules/ROOT/pages/workspace.adoc
@@ -11,10 +11,10 @@ To use a subdirectory, the environment property `workspace` should be set.
 When running within the container:
 
   $ ant -Dworkspace=clientA <target>
-  
+
 When using the container image with the calling script:
 
-  $ iati-workbench -xml -w clientA <target>
+  $ aida-s2i -xml -w clientA <target>
 
 The workspace name can contain multiple levels.
 
@@ -43,11 +43,11 @@ Consider you have a local machine set up with a directory structure:
 └── README.md
 ....
 
-=== Option 1: go into each client directory and run iati-workbench there
+=== Option 1: go into each client directory and run aida-s2i there
 
   $ cd ~/workspaces/clientA
-  $ iati-workbench ...
+  $ aida-s2i ...
 
-=== Option 2: run iati-workbench with -w
+=== Option 2: run aida-s2i with -w
 
-  $ iati-workbench -w s2i/clientA ...
+  $ aida-s2i -w s2i/clientA ...

--- a/docs/modules/spreadsheets2iati/pages/index.adoc
+++ b/docs/modules/spreadsheets2iati/pages/index.adoc
@@ -1,6 +1,7 @@
 = Spreadsheets2IATI
 
-Convertor.
+Combine and convert spreadsheets and IATI files into a single set of files
+for IATI activities and IATI organisations.
 
 == Setup notes
 
@@ -8,7 +9,7 @@ Convertor.
 
 Create a directory for the workspace if it does not exist.
 
-Initialise the workspace, for instance with `iati-workbench init`
+Initialise the workspace, for instance with `aida-s2i init`
 
 Create or copy a `build.xml` to have local build capabilities: for instance to get files from a folder synchronised with Google Drive.
 
@@ -17,7 +18,7 @@ Create or copy a `build.xml` to have local build capabilities: for instance to g
 The conversion process is initiated by a local call of `ant` in the workspace.
 
   $ ant s2i-run
-  
+
 The process breaks down in a couple of components.
 
 .Sequence for `s2i-run`
@@ -28,19 +29,19 @@ start
 partition s2i-run {
   $group_main_color:get-inputs;
   note right: Collect files from remote sources\n(not needed in AIDA)
-  
+
   partition spreadsheet-iati {
     $group_main_color:gather-input-files;
     note right: Prepare input files from input/ to tmp/
-    
+
     $group_main_color:generate-iati-partials;
-    note right: Generate IATI for each file individually 
-    
+    note right: Generate IATI for each file individually
+
     $group_main_color:create-iati-output;
     note right
       Merge generated IATI into one file and
       (not in AIDA) filter out into valid and invalid activities
-    end note 
+    end note
   }
 
   $group_main_color:postprocess-iati;
@@ -59,7 +60,7 @@ This makes it possible to extend or override the process in a particular workspa
 
 === Get inputs
 
-This step copies input files for the conversion 
+This step copies input files for the conversion
 
 [plantuml]
 ....
@@ -74,7 +75,7 @@ $node_1_main_color:inputs/*.*]
 note $important_color
   TODO: check if needed
   Rename files, remove
-  empty files, etc. 
+  empty files, etc.
   override via local ""build.xml""
 end note
 $node_1_main_color:updates inputs/*]
@@ -100,15 +101,15 @@ partition spreadsheet-map {
       :csv-csv;
       $node_1_main_color:tmp/*.csv]
     end fork
-    
+
     :csv-csvxml;
     note: using basex
     $node_1_main_color:tmp/*.csv.xml]
   }
-  
+
   :create map;
   $node_1_main_color:output/csvmap-csv]
-  
+
 }
 (2)
 ....
@@ -130,7 +131,7 @@ end note
 
 === Gather input files
 
-This step takes files from the input folder, 
+This step takes files from the input folder,
 and prepares them for processing, in a flat folder.
 
 * Excel files are converted into CSV.
@@ -155,7 +156,7 @@ fork
       :csv-csv;
       $node_1_main_color:tmp/*.csv]
     end fork
-    
+
     :csv-csvxml;
     note: using basex
     $node_1_main_color:tmp/*.csv.xml]
@@ -173,7 +174,7 @@ end fork
 === Generate IATI partials
 
 This step transforms prepared input files into "partial IATI" files.
-These intermediary files are not valid IATI yet, 
+These intermediary files are not valid IATI yet,
 but contain the IATI representation for the particular input file.
 
 [plantuml]
@@ -187,7 +188,7 @@ note: extension point
 fork
   partition csvxml-s2i {
     $node_1_main_color:tmp/*.csv.xml]
-    
+
     $important_color:config/csvxml-iati.xslt]
     note
       Can include or override
@@ -221,7 +222,7 @@ $node_1_main_color:tmp/*.generated.xml]
 This step combines all "partial IATI files" into one IATI activities and one IATI organisations file.
 These files can contain activities that are not IATI schema-compliant.
 
-With a paid Saxon license, it is possible to validate the file 
+With a paid Saxon license, it is possible to validate the file
 and then split it at the activity level.
 This will create one valid IATI file,
 and one file with activities that contain validation errors.
@@ -263,7 +264,7 @@ title In the workspace
 :postprocess iati;
 note $important_color
   TODO: check if needed
-  Fix known data errors, 
+  Fix known data errors,
   do anonymisation, etc
   override via local ""build.xml""
 end note
@@ -295,12 +296,11 @@ stop
 == Ant targets in the IATI Workbench
 
 .The dependencies of Ant targets involved in `spreadsheet-iati`
-image::image$ant-spreadsheet-iati.svg[] 
+image::image$ant-spreadsheet-iati.svg[]
 
 == IATI Summary
 
 Creates spreadsheets with summary information based on XML files in the `output` folder.
 
-To create those XML files in the output folder, 
+To create those XML files in the output folder,
 we need to run a validation and then filter activities.
- 

--- a/docs/modules/spreadsheets2iati/pages/index.adoc
+++ b/docs/modules/spreadsheets2iati/pages/index.adoc
@@ -204,12 +204,12 @@ fork again
 fork again
   partition akvo-s2i {
     $node_1_main_color:tmp/*.akvo.xml]
-    $important_color:config/akvo-s2i.xslt]
-    note
-      Expects an Akvo-specific
-      config file.
-    end note
-    :akvo-s2i;
+    if (Akvo-specific config file exists) then (yes)
+      $important_color:config/akvo-s2i.xslt]
+      :akvo-s2i;
+    else (no)
+      :iati-s2i;
+    endif
   }
 end fork
 

--- a/spreadsheet-iati/build.xml
+++ b/spreadsheet-iati/build.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--  IATI workbench: produce and use IATI data
   Copyright (C) 2016-2022, drostan.org and data4development.org
-  
+
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published
   by the Free Software Foundation, either version 3 of the License, or
   (at your option) any later version.
-  
+
   This program is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
   GNU Affero General Public License for more details.
-  
+
   You should have received a copy of the GNU Affero General Public License
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
--->  
+-->
 <project name="spreadsheet-iati"
   xmlns:if="ant:if"
   xmlns:unless="ant:unless">
@@ -34,7 +34,7 @@
   <extension-point name="generate-iati-partials"
     description="Generate IATI partial activities for input files"
     depends="csvxml-s2i, iati-s2i, akvo-s2i"/>
-  
+
   <extension-point name="create-iati-output"
     description="Merge IATI partial activities, validate, create clean output"
     depends="merge-iati"/>
@@ -64,7 +64,7 @@
       <fileset dir="${ws}/input" includes="**/*.iati.xml, **/*.akvo.xml"/>
     </copy>
   </target>
-  
+
   <!--Convert spreadsheets to CSV files for further processing.-->
   <target name="excel-csv">
     <echo level="info">Convert spreadsheets to CSV files for further processing.</echo>
@@ -113,10 +113,12 @@
   </target>
 
   <!--Transform existing Akvo input files using workspace-based config.-->
+  <target name="akvo-s2i" depends="check-akvo-config, akvo-s2i-custom, akvo-s2i-generic"/>
+
   <target name="check-akvo-config">
     <available property="has.akvo.config" file="${ws}/config/akvo-s2i.xslt"/>
   </target>
-  <target name="akvo-s2i" depends="check-akvo-config" if="has.akvo.config">
+  <target name="akvo-s2i-custom" depends="check-akvo-config" if="has.akvo.config">
     <xslt
       basedir="${ws}/tmp/"
       includes="*.akvo.xml"
@@ -124,6 +126,15 @@
       extension=".generated.xml"
       style="${ws}/config/akvo-s2i.xslt"
      />
+  </target>
+  <target name="akvo-s2i-generic" depends="check-akvo-config" unless="has.akvo.config">
+    <xslt
+      basedir="${ws}/tmp/"
+      includes="*.akvo.xml"
+      destdir="${ws}/tmp"
+      extension=".generated.xml"
+      style="transform/add-merge-ids.xslt"
+    />
   </target>
 
   <target name="sheets-csvxml" depends="excel-csv, csv-csv">
@@ -147,11 +158,11 @@
       style="lib/iati.me/csvxml-map.xslt"
     />
   </target>
-  
+
   <!-- empty target to override if actions are needed after downloading remote files -->
   <extension-point name="postprocess-inputs"/>
-  
+
   <!-- can  be overridden to do something with the IATI files before publishing -->
   <target name="postprocess-iati"/>
-  
+
 </project>

--- a/spreadsheet-iati/build.xml
+++ b/spreadsheet-iati/build.xml
@@ -104,7 +104,7 @@
   <!--Transform existing IATI input files into a version with merge ids.-->
   <target name="iati-s2i">
     <xslt
-      basedir="${ws}/input/"
+      basedir="${ws}/tmp/"
       includes="*.iati.xml"
       destdir="${ws}/tmp"
       extension=".generated.xml"


### PR DESCRIPTION
### Improvements

* handle utf8 in filenames aa9c141
* merge-activities shouldn't include related-activity with empty [@ref](undefined/ref) 1a0a053
* no duplication of participating-orgs without [@ref](undefined/ref) 8f7caa4
* process Akvo files as regular IATI when no custom config exists 9297874
* run iati-s2i for files in the tmp folder 8ee4c86
* skip empty activity title and description narratives 7eb6847

### Documentation

* make aida-s2i consistent 9b995ff
